### PR TITLE
fix: fix inadvertent sharing of clients

### DIFF
--- a/lib/KnormPostgres.js
+++ b/lib/KnormPostgres.js
@@ -27,93 +27,34 @@ class KnormPostgres {
     }
   }
 
-  _releaseClient() {
-    this.client.release();
-    this.client = null;
-  }
-
+  // TODO: throw custom errors
   async acquireClient() {
-    if (this.client) {
-      return;
-    }
-
-    this.client = await this.pool.connect();
+    const client = await this.pool.connect();
 
     if (this._initClient) {
       try {
-        await this._initClient(this.client);
+        await this._initClient(client);
       } catch (e) {
-        this._releaseClient();
-        throw e;
-      }
-    }
-  }
-
-  async releaseClient() {
-    if (!this.client) {
-      return;
-    }
-
-    if (this._restoreClient) {
-      try {
-        await this._restoreClient(this.client);
-      } catch (e) {
-        this._releaseClient();
+        client.release();
         throw e;
       }
     }
 
-    this._releaseClient();
-  }
-
-  async query(query) {
-    await this.acquireClient();
-
-    const result = await this.client.query(
-      typeof query === 'string' ? query : query.toParams()
-    );
-
-    if (!this.transacting) {
-      await this.releaseClient();
-    }
-
-    return result;
+    return client;
   }
 
   // TODO: throw custom errors
-  async transact(transaction) {
-    let result;
-
-    await this.acquireClient();
-    this.transacting = true;
-
-    try {
-      await this.query('BEGIN');
+  async releaseClient(client) {
+    if (this._restoreClient) {
       try {
-        result = await transaction(this.client);
-        await this.query('COMMIT');
-      } catch (transactionError) {
-        try {
-          await this.query('ROLLBACK');
-        } catch (rollbackError) {
-          const error = new KnormPostgresError(
-            'unable to roll back after a failed transaction'
-          );
-          error.transactionError = transactionError;
-          error.rollbackError = rollbackError;
-          throw error;
-        }
-        throw transactionError;
-      }
-    } finally {
-      try {
-        await this.releaseClient();
-      } finally {
-        this.transacting = false;
+        await this._restoreClient(client);
+      } catch (e) {
+        client.release();
+        throw e;
       }
     }
 
-    return result;
+    client.release();
   }
 
   updateField(knorm) {
@@ -145,8 +86,70 @@ class KnormPostgres {
     const knormPostgres = this;
 
     knorm.Transaction = class PostgresTransaction extends Transaction {
+      constructor(...args) {
+        super(...args);
+
+        const transaction = this;
+
+        this.Field = knorm.Field;
+        this.Model = class TransactionModel extends knorm.Model {};
+        this.Query = this.Model.Query = class TransactionQuery extends knorm.Query {
+          async query(sql) {
+            return transaction.query(sql);
+          }
+        };
+
+        Object.entries(knorm.models).forEach(([name, model]) => {
+          this[name] = class TransactionModel extends model {};
+          this[name].Query = class TransactionQuery extends this[name].Query {
+            async query(sql) {
+              return transaction.query(sql);
+            }
+          };
+        });
+      }
+
+      async query(sql) {
+        const result = await this.client.query(
+          typeof sql === 'string' ? sql : sql.toParams()
+        );
+        return result.rows;
+      }
+
+      // TODO: throw custom errors
       async execute() {
-        return knormPostgres.transact(this.transaction);
+        let result;
+
+        this.client = await knormPostgres.acquireClient();
+
+        try {
+          await this.query('BEGIN');
+          try {
+            // eslint-disable-next-line no-useless-call
+            result = await this.transaction.call(this, this.client);
+            await this.query('COMMIT');
+          } catch (transactionError) {
+            try {
+              await this.query('ROLLBACK');
+            } catch (rollbackError) {
+              const error = new KnormPostgresError(
+                'unable to roll back after a failed transaction'
+              );
+              error.transactionError = transactionError;
+              error.rollbackError = rollbackError;
+              throw error;
+            }
+            throw transactionError;
+          }
+        } finally {
+          try {
+            await knormPostgres.releaseClient(this.client);
+          } finally {
+            this.client = null;
+          }
+        }
+
+        return result;
       }
     };
   }
@@ -256,7 +259,11 @@ class KnormPostgres {
       }
 
       async query(sql) {
-        const result = await knormPostgres.query(sql);
+        const client = await knormPostgres.acquireClient();
+        const result = await client.query(
+          typeof sql === 'string' ? sql : sql.toParams()
+        );
+        await knormPostgres.releaseClient(client);
         return result.rows;
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "dependencies": {
     "@knorm/knorm": {
-      "version": "github:knorm/knorm#e7f2a1df3b6f9580482079ef6d12192d8b9a852a",
+      "version": "github:knorm/knorm#b6a1f7b5d5325072f86a521311480468ff16fdf0",
       "dev": true,
       "requires": {
         "lodash": "4.17.10",
@@ -904,7 +904,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {


### PR DESCRIPTION
observed with:

```js
class Foo extends Model {
  async validate() {
    await super.validate();
    await Foo.fetch(); // this would share the client acquired by insert
  }
}

Foo.insert(); // trigger the bug

```