### PR TITLE
fix: added condition to only stringify objects on updateField

### DIFF
--- a/lib/KnormPostgres.js
+++ b/lib/KnormPostgres.js
@@ -69,7 +69,11 @@ class KnormPostgres {
             if (this.castors && this.castors.forSave) {
               return super.cast(value, modelInstance, options);
             }
-            return JSON.stringify(value);
+            if (typeof value === 'object') {
+              return JSON.stringify(value);
+            } else {
+              return value;
+            }
           }
 
           if (options.forFetch) {

--- a/test/KnormPostgres.spec.js
+++ b/test/KnormPostgres.spec.js
@@ -270,6 +270,15 @@ describe('KnormPostgres', () => {
             expect(forSave, 'was called on', instance);
           });
         });
+
+        it(`does not stringify a sting`, () => {
+          const field = new Field({ name: 'foo', model: Model, type: 'json' });
+          expect(
+            field.cast('hello there', null, { forSave: true }),
+            'to equal',
+            'hello there'
+          );
+        });
       });
 
       describe('forFetch', () => {


### PR DESCRIPTION
There was a bug on which the JSON field that was a `string` was being over-stringified on save.
Added condition to only stringify objects on updateField when field is of type JSON.
