### PR TITLE
feat: add transaction flags

### DIFF
--- a/lib/KnormPostgres.js
+++ b/lib/KnormPostgres.js
@@ -114,6 +114,41 @@ class KnormPostgres {
     const knormPostgres = this;
 
     class PostgresTransaction extends Transaction {
+      constructor(...args) {
+        super(...args);
+
+        const transaction = this;
+
+        // NOTE: in order to call the super `query` method once the transaction
+        // is ended, postgres transaction models need to extend the original
+        // `this.knorm.models` as opposed to `this.models`. The bad news is that
+        // this makes it impossible for custom code to overload `this.models`
+        // for Transactions, the good news is that this is fixed in v2.
+        this.models = Object.entries(this.knorm.models).reduce(
+          (models, [name, model]) => {
+            // extending this way doesn't overwrite the model's name
+            models[name] = class extends model {};
+            models[name].Query = class extends model.Query {
+              async query(sql) {
+                if (transaction.active === false) {
+                  return super.query(sql);
+                }
+
+                return transaction.query(sql);
+              }
+            };
+
+            [models[name], models[name].Query].forEach(scopedClass => {
+              scopedClass.prototype.models = scopedClass.models = models;
+              scopedClass.prototype.transaction = scopedClass.transaction = transaction;
+            });
+
+            return models;
+          },
+          {}
+        );
+      }
+
       async acquireClient() {
         this.client = await knormPostgres.acquireClient();
       }

--- a/lib/KnormPostgres.js
+++ b/lib/KnormPostgres.js
@@ -130,7 +130,7 @@ class KnormPostgres {
             models[name] = class extends model {};
             models[name].Query = class extends model.Query {
               async query(sql) {
-                if (transaction.active === false) {
+                if (transaction.ended) {
                   return super.query(sql);
                 }
 
@@ -178,6 +178,7 @@ class KnormPostgres {
         try {
           await this._query('BEGIN');
           this.active = true;
+          this.started = true;
         } catch (e) {
           throw new this.constructor.TransactionBeginError(e);
         }
@@ -187,6 +188,7 @@ class KnormPostgres {
         try {
           await this._query('COMMIT');
           this.active = false;
+          this.ended = true;
         } catch (e) {
           throw new this.constructor.TransactionCommitError(e);
         }
@@ -196,6 +198,7 @@ class KnormPostgres {
         try {
           await this._query('ROLLBACK');
           this.active = false;
+          this.ended = true;
         } catch (e) {
           throw new this.constructor.TransactionRollbackError(e);
         }

--- a/lib/KnormPostgres.js
+++ b/lib/KnormPostgres.js
@@ -142,6 +142,7 @@ class KnormPostgres {
       async _begin() {
         try {
           await this._query('BEGIN');
+          this.active = true;
         } catch (e) {
           throw new this.constructor.TransactionBeginError(e);
         }
@@ -150,6 +151,7 @@ class KnormPostgres {
       async _commit() {
         try {
           await this._query('COMMIT');
+          this.active = false;
         } catch (e) {
           throw new this.constructor.TransactionCommitError(e);
         }
@@ -158,6 +160,7 @@ class KnormPostgres {
       async _rollback() {
         try {
           await this._query('ROLLBACK');
+          this.active = false;
         } catch (e) {
           throw new this.constructor.TransactionRollbackError(e);
         }

--- a/test/KnormPostgres.spec.js
+++ b/test/KnormPostgres.spec.js
@@ -2406,6 +2406,22 @@ describe('KnormPostgres', () => {
           await transaction.rollback();
         });
 
+        it('sets the `started` flag to `true`', async () => {
+          const transaction = new Transaction();
+          await expect(transaction.started, 'to be undefined');
+          await transaction.begin();
+          await expect(transaction.started, 'to be true');
+          await transaction.rollback();
+        });
+
+        it('leaves the `ended` flag as `undefined`', async () => {
+          const transaction = new Transaction();
+          await expect(transaction.ended, 'to be undefined');
+          await transaction.begin();
+          await expect(transaction.ended, 'to be undefined');
+          await transaction.rollback();
+        });
+
         it('rolls back the transaction on failure', async () => {
           const transaction = new Transaction();
           const spy = sinon.spy(transaction, '_rollback');
@@ -2510,6 +2526,22 @@ describe('KnormPostgres', () => {
           await expect(transaction.active, 'to be false');
         });
 
+        it('sets the `ended` flag to `true`', async () => {
+          const transaction = new Transaction();
+          await transaction.begin();
+          await expect(transaction.ended, 'to be undefined');
+          await transaction.commit();
+          await expect(transaction.ended, 'to be true');
+        });
+
+        it('leaves the `started` flag as `true`', async () => {
+          const transaction = new Transaction();
+          await transaction.begin();
+          await expect(transaction.started, 'to be true');
+          await transaction.commit();
+          await expect(transaction.started, 'to be true');
+        });
+
         it('rolls back the transaction on failure', async () => {
           const transaction = new Transaction();
           const spy = sinon.spy(transaction, '_rollback');
@@ -2573,6 +2605,22 @@ describe('KnormPostgres', () => {
           await expect(transaction.active, 'to be true');
           await transaction.rollback();
           await expect(transaction.active, 'to be false');
+        });
+
+        it('sets the `ended` flag to `true`', async () => {
+          const transaction = new Transaction();
+          await transaction.begin();
+          await expect(transaction.ended, 'to be undefined');
+          await transaction.rollback();
+          await expect(transaction.ended, 'to be true');
+        });
+
+        it('leaves the `started` flag as `true`', async () => {
+          const transaction = new Transaction();
+          await transaction.begin();
+          await expect(transaction.started, 'to be true');
+          await transaction.rollback();
+          await expect(transaction.started, 'to be true');
         });
 
         it('releases the client on failure', async () => {

--- a/test/KnormPostgres.spec.js
+++ b/test/KnormPostgres.spec.js
@@ -2342,6 +2342,14 @@ describe('KnormPostgres', () => {
           await expect(spy, 'was called once');
         });
 
+        it('sets the `active` flag to `true`', async () => {
+          const transaction = new Transaction();
+          await expect(transaction.active, 'to be undefined');
+          await transaction.begin();
+          await expect(transaction.active, 'to be true');
+          await transaction.rollback();
+        });
+
         it('rolls back the transaction on failure', async () => {
           const transaction = new Transaction();
           const spy = sinon.spy(transaction, '_rollback');
@@ -2438,6 +2446,14 @@ describe('KnormPostgres', () => {
       });
 
       describe('commit', () => {
+        it('sets the `active` flag to `false`', async () => {
+          const transaction = new Transaction();
+          await transaction.begin();
+          await expect(transaction.active, 'to be true');
+          await transaction.commit();
+          await expect(transaction.active, 'to be false');
+        });
+
         it('rolls back the transaction on failure', async () => {
           const transaction = new Transaction();
           const spy = sinon.spy(transaction, '_rollback');
@@ -2495,6 +2511,14 @@ describe('KnormPostgres', () => {
       });
 
       describe('rollback', () => {
+        it('sets the `active` flag to `false`', async () => {
+          const transaction = new Transaction();
+          await transaction.begin();
+          await expect(transaction.active, 'to be true');
+          await transaction.rollback();
+          await expect(transaction.active, 'to be false');
+        });
+
         it('releases the client on failure', async () => {
           let client;
           const transaction = new Transaction();


### PR DESCRIPTION
- adds `started`, `active` and `ended` flags. 
- adds a critical fix to ensure queries are run outside a transaction once it's ended (committed or rolled back)