### PR TITLE
fix: pass query errors to client.release

### DIFF
--- a/lib/KnormPostgres.js
+++ b/lib/KnormPostgres.js
@@ -72,8 +72,8 @@ class KnormPostgres {
         return rows;
       }
 
-      async close() {
-        return this.client.release();
+      async close(error) {
+        return this.client.release(error);
       }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,9 +112,9 @@
       }
     },
     "@knorm/knorm": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@knorm/knorm/-/knorm-2.0.0.tgz",
-      "integrity": "sha512-+RStVPCo4A9iJYuxW7A4ApATdtOz8tdvTydU8Ut2JoThxW/1A1gWhUBOl2qkm9/La8CZwT+Ieady06d3Tkzfvg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@knorm/knorm/-/knorm-2.1.0.tgz",
+      "integrity": "sha512-VHVh1zijOVCBs/iTCvoQdKZCUZghryu32lRC3OQrZ3vUt3obCfXWGffQaPsC5eEQ4cOL7w7cDiDCI7LszC2uZA==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.5",
@@ -797,7 +797,7 @@
       "dependencies": {
         "callsites": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "dev": true
         }
@@ -2346,7 +2346,7 @@
       "dependencies": {
         "split2": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
           "integrity": "sha1-UuLiIdiMdfmnP5BVbiY/+WdysxQ=",
           "dev": true,
           "requires": {
@@ -2975,7 +2975,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -3489,7 +3489,7 @@
         },
         "supports-color": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
           "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
           "dev": true
         }
@@ -3567,7 +3567,7 @@
       "dependencies": {
         "p-is-promise": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
           "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
           "dev": true
         }
@@ -8220,7 +8220,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },
@@ -9004,7 +9004,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -9082,7 +9082,7 @@
     },
     "semver": {
       "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
+      "resolved": "http://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
       "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
     },
     "semver-regex": {
@@ -9409,7 +9409,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -9423,7 +9423,7 @@
       "dependencies": {
         "underscore": {
           "version": "1.4.4",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+          "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
           "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
         }
       }
@@ -9508,7 +9508,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
@@ -9532,7 +9532,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -9623,7 +9623,7 @@
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },
@@ -9641,7 +9641,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -10094,7 +10094,7 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         }
@@ -10133,7 +10133,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@knorm/relations": "^2.0.0"
   },
   "devDependencies": {
-    "@knorm/knorm": "2.0.0",
+    "@knorm/knorm": "2.1.0",
     "@knorm/relations": "2.0.0",
     "@semantic-release/changelog": "3.0.2",
     "@semantic-release/git": "7.0.8",


### PR DESCRIPTION
Trying out the suggestion in https://github.com/brianc/node-postgres/issues/1745#issuecomment-427962815 in an attempt to fix "Client was closed and is not queryable" errors.

Depends on https://github.com/knorm/knorm/pull/233