### PR TITLE
fix: use bind parameter for json patches

### DIFF
--- a/lib/KnormPostgres.js
+++ b/lib/KnormPostgres.js
@@ -245,12 +245,14 @@ class KnormPostgres {
 
         const isJson = this.config.fields[field].type === 'json';
         let patch = isJson ? `${column}::jsonb` : column;
+        const values = [];
+        const addValue = value => `$${values.push(value)}`;
 
         Object.entries(value).forEach(([key, value]) => {
           if (value !== undefined) {
-            patch = `jsonb_set(${patch}, '{${key}}', '${JSON.stringify(
-              value
-            )}')`;
+            patch = `jsonb_set(${patch}, ${addValue(`{${key}}`)}, ${addValue(
+              JSON.stringify(value)
+            )})`;
           }
         });
 
@@ -258,7 +260,7 @@ class KnormPostgres {
           patch = `${patch}::json`;
         }
 
-        return this.sql(patch);
+        return this.sql(patch, values);
       }
 
       // TODO: support using column names in the raw sql for multi-updates

--- a/test/KnormPostgres.spec.js
+++ b/test/KnormPostgres.spec.js
@@ -1712,6 +1712,43 @@ describe('KnormPostgres', () => {
             )
           );
         });
+
+        it('updates the json object containing single quotes', async () => {
+          const query = new Query(Foo)
+            .where({ id: 1 })
+            .first()
+            .patch();
+          await expect(
+            query.update({
+              jsonb: { string: `bar ' ` },
+              json: { string: `bar ' ` }
+            }),
+            'to be fulfilled with value exhaustively satisfying',
+            new Foo({
+              id: 1,
+              jsonb: {
+                string: `bar ' `,
+                number: 1,
+                array: ['foo', 'bar'],
+                object: {
+                  string: 'foo',
+                  number: 1,
+                  array: ['foo', 'bar']
+                }
+              },
+              json: {
+                string: `bar ' `,
+                number: 1,
+                array: ['foo', 'bar'],
+                object: {
+                  string: 'foo',
+                  number: 1,
+                  array: ['foo', 'bar']
+                }
+              }
+            })
+          );
+        });
       });
     });
   });


### PR DESCRIPTION
This pull request fixes a bug where the json patch would break if `value` contains a quote.

Because the code was appending to the string, the generated query would have an unescaped single quote, which enables injection problems.

The PR changes the query to use bind parameters for the query, eliminating injection issues.