### PR TITLE
fix: do not stringify null values

### DIFF
--- a/lib/KnormPostgres.js
+++ b/lib/KnormPostgres.js
@@ -21,7 +21,8 @@ class KnormPostgres {
           (this.type === 'json' || this.type === 'jsonb') &&
           !(value instanceof knorm.Query.prototype.sql) &&
           options.forSave &&
-          !(this.castors && this.castors.forSave)
+          !(this.castors && this.castors.forSave) &&
+          value !== null
         ) {
           return JSON.stringify(value);
         }

--- a/test/KnormPostgres.spec.js
+++ b/test/KnormPostgres.spec.js
@@ -169,6 +169,11 @@ describe('KnormPostgres', () => {
           Query.prototype.sql = sql;
         });
 
+        it('does not stringify `null` values', () => {
+          const field = new Field({ name: 'foo', model: Model, type: 'json' });
+          expect(field.cast(null, null, { forSave: true }), 'to be undefined');
+        });
+
         describe('with a forSave cast function configured', () => {
           it('uses the configred function', () => {
             const field = new Field({


### PR DESCRIPTION
This pull requests fixes a bug where `json(b)` `null` values were being cast to string.

Added test is similar to the [one removed from `v2.0.4`](https://github.com/knorm/postgres/commit/55eaf6bda0c390e5bde172a0c7d64a76081bdf48?diff=split#diff-b46c882c0e2cb0595464adc75393fa44L153)